### PR TITLE
ci: add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch: # Permette l'avvio manuale dalla scheda Actions
 
+# Permessi minimi di default per tutti i job; il job deploy li sovrascrive
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Cosa

Aggiunge un blocco `permissions` top-level con privilegi minimi al workflow `deploy.yml`.

## Perché

CodeQL code scanning ha sollevato l'alert `actions/missing-workflow-permissions`: il job `lint-and-test` girava con il `GITHUB_TOKEN` ai permessi di default (scope di scrittura). Senza un blocco esplicito, il token ha più privilegi del necessario.

## Modifica

- Top-level `permissions: contents: read` → applicato a tutti i job (copre `lint-and-test`, che fa solo checkout).
- Il job `deploy` mantiene il suo override esplicito (`contents: read` + `packages: write`) necessario per il push dell'immagine su ghcr.io.

Flusso completo verificato: nessun job perde permessi necessari.

Risolve l'alert CodeQL `actions/missing-workflow-permissions`.